### PR TITLE
Support for supertest-based testing

### DIFF
--- a/src/exception/RollbackError.ts
+++ b/src/exception/RollbackError.ts
@@ -1,0 +1,5 @@
+export class RollbackError extends Error {
+    constructor(message: string) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Motivation

I'm developing using _typescript, express, typeorm, jest, [supertest](https://github.com/visionmedia/supertest)_, I found out your repository because I had needed integration tests.
But when I did the integration test with supertest, I found that it passed the test that should fail.
supertest module throws an exception if it does not match the expected result and the `TransactionCreator.run()` method **does not distinguish between these and rollback errors**.
So **I suggest distinguishing error cases to support supertest!**

## Test

### User router

 ```javascript
router.get("/api/users/:name",  async (request: Request, response: Response) => {
  const name = request.params.name;
  const user = await User.findOne({where: {name: name}});
  return response
          .status(200)
          .json(user);
});
```
### Test code

```javascript
test("should fail, if not match response body with expected object.", runInTransaction(async () => {
  // given
  const user = await User.create({
    name: "test_name",
    address: "test_address",
    age: 21
  }).save();

  const wrongName = "wrong_name";

  // when, then
  await app.get("/api/users/" + wrongName)
          .expect(200)
          .expect({...user}); // Test must fail because the name is different.

}));
```

## Current Result

> As the picture below, it passes even if the test fails. 

![image](https://user-images.githubusercontent.com/16451031/69497572-f2cbc780-0f21-11ea-995c-0edfa7094295.png)

## Expected Result
> **Distinguishing between errors for rollbacks and others can help pinpoint the failed test case.**

![image](https://user-images.githubusercontent.com/16451031/69497517-438ef080-0f21-11ea-8440-7f5542ebe752.png)

