### PR TITLE
Tests won't fail; is runInTransaction running?

### DIFF
--- a/tests/rollback.spec.ts
+++ b/tests/rollback.spec.ts
@@ -28,13 +28,25 @@ describe('rollback tests', () => {
         });
 
         await runInTransaction(async () => {
+            console.log("create another User ... 2");
+
             const user = User.create({ email });
             await user.save();
             const found = await User.findOne({
                 where: { email },
             });
             expect(found).toBeDefined();
+            expect(false).toBeTruthy();
         });
+    });
+
+    it('never seems to fail', async () => {
+        console.log("log outside runInTransaction");
+        await runInTransaction(async () => {
+            console.log("log inside runInTransaction");
+            expect(false).toBeTruthy();
+        });
+        console.log("log after runInTransaction");
     });
 
     it('rolls back multiple inserts', async () => {


### PR DESCRIPTION
I am reproducing an issue I found in my own code base -- code inside `await runInTransaction(async () => { ... })` does not fail its expectations; and it swallows `console.log` output. So perhaps the block inside `runInTransaction` is not running at all?

This commit includes a failing test but the test suite doesn't fail.

The output I see is:

```
 PASS  tests/rollback.spec.ts
  ● Console

    console.log
      log outside runInTransaction

      at Object.<anonymous> (tests/rollback.spec.ts:44:17)

    console.log
      log after runInTransaction

      at Object.<anonymous> (tests/rollback.spec.ts:49:17)

 PASS  tests/entity-creation.spec.ts
 PASS  tests/rollback-second-file.spec.ts
```

But I should also see `log inside runInTransaction` and the spec should not pass.

Ideas?